### PR TITLE
add onnxsim

### DIFF
--- a/nne/common.py
+++ b/nne/common.py
@@ -1,5 +1,6 @@
 import platform
 import os
+import onnxsim
 
 def check_jetson():
     if platform.machine() == "aarch64":
@@ -16,3 +17,8 @@ def check_tensorrt():
 
 def check_model_is_cuda(model):
     return next(model.parameters()).is_cuda
+
+def onnx_simplify(model, input_shapes):
+    model_opt, check_ok = onnxsim.simplify(
+        model, check_n=3, perform_optimization=False, skip_fuse_bn=False, input_shapes=None)
+    return model_opt, check_ok

--- a/nne/onnx.py
+++ b/nne/onnx.py
@@ -30,9 +30,13 @@ def cv2onnx(model, input_shape, onnx_file):
             onnx.checker.check_model(onnx_model)
         else:
             print("[ERR]:",e)
+            sys.exit()
     except Exception as e:
         print("[ERR]:", e)
         sys.exit()
+    model_opt, check_ok = onnx_simplify(onnx_model, input_shape)
+    if check_ok:
+        onnx.save(model_opt, onnx_file)
 
 
 def load_onnx(onnx_file):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def check_gpu_enable():
     return torch.cuda.is_available()
 
 def get_requires():
-    requires = ["onnx", "tensorflow-cpu", "tensorflow_addons", "onnx_tf @ git+https://github.com/onnx/onnx-tensorflow", "torchvision", "matplotlib"]
+    requires = ["onnx", "tensorflow-cpu", "tensorflow_addons", "onnx_tf @ git+https://github.com/onnx/onnx-tensorflow", "torchvision", "matplotlib", "onnx-simplifier"]
     if check_tensorrt():
         requires += ["pycuda"]
     else:


### PR DESCRIPTION
Conversion of onnx model to TensorRT model fails. Due to Upsample layer, use onnx-simplifer as a countermeasure and delete unnecessary nodes.

https://github.com/NVIDIA/TensorRT/issues/284#issuecomment-568349214